### PR TITLE
Add underline style to links

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -12,7 +12,7 @@ columns:
 
   - name: Code
     description: | # Can be Markdown
-      This project is open source. See the code on [Github](https://github.com/gbif/hp-biodiversity-data-journal).
+      This project is open source. See the code on [GitHub](https://github.com/gbif/hp-biodiversity-data-journal).
   
   - name: Contact
     description: | # Can be Markdown

--- a/_sass/_example.scss
+++ b/_sass/_example.scss
@@ -97,3 +97,9 @@
 .dashboard {
     margin-top: 4rem;
 }
+
+.article {
+  a {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
Right now, I couldn't tell that some of the text was links, as I have red-green deficiency (along with around 1/8th of your users, mostly likely). In order to make it clearer, I added underlines to links. 

I also changed Github to GitHub in the footer, in alignment with their style guide. 